### PR TITLE
fix model params num mismatch

### DIFF
--- a/configs/summit_clipH_pythia70m.yml
+++ b/configs/summit_clipH_pythia70m.yml
@@ -6,7 +6,7 @@
 
     # language model settings
     lm_name: "neox",
-    lm_path: "EleutherAI/pythia-19m",
+    lm_path: "EleutherAI/pythia-70m-deduped",
 
     # train settings
     batch_size: 256,

--- a/magma/language_model.py
+++ b/magma/language_model.py
@@ -49,19 +49,12 @@ def get_gptj(
     return model
 
 def neox_config(path: Optional[str] = None):
-    config = AutoConfig.from_pretrained(path if path is not None else "EleutherAI/pythia-19m")
-    config.attention_layers = ["global"] * 28
-    config.attention_types = [["global"], 28]
-    config.num_layers = 28
-    config.num_heads = 16
-    config.hidden_size = 256 * config.num_heads
-    config.vocab_size = 50400
+    config = AutoConfig.from_pretrained(path if path is not None else "EleutherAI/pythia-70m-deduped")
     config.rotary = True
     config.rotary_dim = 64
     config.jax = True
     config.gradient_checkpointing = True
     return config
-
 
 def get_neox(
     path: str = None,


### PR DESCRIPTION
- remove addition shape config for gpt-neox.

  - old magma do additional shape config to expand gpt-neo-2.7B to gptj-6b
     https://github.com/finetunej/transformers#gpt-j-6b

  - gpt-neox models can be loaded directly, additional shape expand config will cause loading unexpected model, should be removed.

- change pythia-19m into pythia-70m-deduped

  - a little misleading because when u load pythia-19m, actually you're loading pythia-70m-deduped
   ```
        model = GPTNeoXForCausalLM.from_pretrained("EleutherAI/pythia-70m-deduped")
        print_num_params(model)
        model = GPTNeoXForCausalLM.from_pretrained("EleutherAI/pythia-19m")
        print_num_params(model)`
        # model size is 70.426624 M
        # model size is 70.426624 M
   ```
I have made a test to show above cases.
    https://github.com/floatingsnake/magma/blob/benchmark/mytests/test_gpt_neox.py
    