### PR TITLE
Remove storing gradient of freezed language model parameter

### DIFF
--- a/magma/magma.py
+++ b/magma/magma.py
@@ -99,6 +99,7 @@ class Magma(nn.Module):
         # freeze parameters
         if config.freeze_lm:
             for name, param in self.lm.named_parameters():  # freeze lm weights
+                param.requires_grad = False
                 if config.adapter_config and "adapter" in name:
                     param.requires_grad = True
 


### PR DESCRIPTION
Language model params except adapter won't be updated, therefore we shouldn't store their gradient. Too much uncessary GPU usage when using large LM model.
This [test](https://github.com/floatingsnake/magma/blob/benchmark/mytests/test_model_freeze.py) shows All params of language model requires grad